### PR TITLE
Fix a permission in tagpr

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      packages: write
+      issues: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/tagpr.yml` file. The change modifies the permissions block, replacing `packages: write` with `issues: write` to adjust access rights for the workflow.