### PR TITLE
Get recursive values from configmap/secret

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,48 @@
+name: Integration Test
+
+on:
+  push:
+    branches: [ main, fix/recursive-secret ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
+    - name: Build kubectl-eex
+      run: make build-plugin
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.9.0
+      with:
+        cluster_name: kind
+
+    - name: Create test namespace
+      run: kubectl create namespace test-keex
+
+    - name: Apply test resources
+      run: |
+        kubectl apply -f test/k8s/ -n test-keex
+
+    - name: Wait for resources to be ready
+      run: |
+        kubectl wait --for=condition=ready pod -l app=test-app -n test-keex --timeout=60s
+
+    - name: Run integration tests
+      run: |
+        chmod +x test/integration/test.sh
+        ./test/integration/test.sh
+
+    - name: Cleanup
+      if: always()
+      run: |
+        kubectl delete namespace test-keex --ignore-not-found=true

--- a/cmd/kubectl-eex/main.go
+++ b/cmd/kubectl-eex/main.go
@@ -218,23 +218,32 @@ func extractFromPodSpec(spec *corev1.PodSpec, containerName string) []extractor.
 
 		// EnvFrom
 		for _, envFrom := range container.EnvFrom {
+			prefix := ""
+			if envFrom.Prefix != "" {
+				prefix = envFrom.Prefix
+			}
+
 			if envFrom.SecretRef != nil {
 				result = append(result, extractor.EnvVar{
-					Name:  fmt.Sprintf("# from secret: %s", envFrom.SecretRef.Name),
-					Value: "",
+					Name:   fmt.Sprintf("# from secret: %s", envFrom.SecretRef.Name),
+					Value:  "",
+					Source: extractor.SourceSecret,
 					SecretRef: &extractor.SecretKeyRef{
 						Name: envFrom.SecretRef.Name,
 						Key:  "*", // All keys
 					},
+					Prefix: prefix,
 				})
 			} else if envFrom.ConfigMapRef != nil {
 				result = append(result, extractor.EnvVar{
-					Name:  fmt.Sprintf("# from configmap: %s", envFrom.ConfigMapRef.Name),
-					Value: "",
+					Name:   fmt.Sprintf("# from configmap: %s", envFrom.ConfigMapRef.Name),
+					Value:  "",
+					Source: extractor.SourceConfigMap,
 					ConfigRef: &extractor.ConfigMapKeyRef{
 						Name: envFrom.ConfigMapRef.Name,
 						Key:  "*", // All keys
 					},
+					Prefix: prefix,
 				})
 			}
 		}

--- a/pkg/extractor/types.go
+++ b/pkg/extractor/types.go
@@ -7,6 +7,7 @@ type EnvVar struct {
 	IsSecret  bool
 	SecretRef *SecretKeyRef
 	ConfigRef *ConfigMapKeyRef
+	Prefix    string // Prefix for envFrom
 }
 
 type EnvVarSource int

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -100,13 +100,37 @@ func (r *Resolver) ResolveAll(envVars []extractor.EnvVar) ([]extractor.EnvVar, e
 					secretCache[envVar.SecretRef.Name] = secret
 				}
 
-				if value, ok := secret.Data[envVar.SecretRef.Key]; ok {
-					envVar.Value = string(value)
+				// Handle envFrom (when Key is "*")
+				if envVar.SecretRef.Key == "*" {
+					// Extract all key-value pairs from the secret
+					for key, value := range secret.Data {
+						envName := key
+						if envVar.Prefix != "" {
+							envName = envVar.Prefix + key
+						}
+						newEnvVar := extractor.EnvVar{
+							Name:   envName,
+							Value:  string(value),
+							Source: extractor.SourceSecret,
+							SecretRef: &extractor.SecretKeyRef{
+								Name: envVar.SecretRef.Name,
+								Key:  key,
+							},
+						}
+						resolved = append(resolved, newEnvVar)
+					}
 				} else {
-					fmt.Fprintf(os.Stderr, "Warning: key %s not found in secret %s\n", envVar.SecretRef.Key, envVar.SecretRef.Name)
+					// Handle specific key reference
+					if value, ok := secret.Data[envVar.SecretRef.Key]; ok {
+						envVar.Value = string(value)
+					} else {
+						fmt.Fprintf(os.Stderr, "Warning: key %s not found in secret %s\n", envVar.SecretRef.Key, envVar.SecretRef.Name)
+					}
+					resolved = append(resolved, envVar)
 				}
+			} else {
+				resolved = append(resolved, envVar)
 			}
-			resolved = append(resolved, envVar)
 
 		case extractor.SourceConfigMap:
 			if envVar.ConfigRef != nil {
@@ -122,13 +146,37 @@ func (r *Resolver) ResolveAll(envVars []extractor.EnvVar) ([]extractor.EnvVar, e
 					configMapCache[envVar.ConfigRef.Name] = configMap
 				}
 
-				if value, ok := configMap.Data[envVar.ConfigRef.Key]; ok {
-					envVar.Value = value
+				// Handle envFrom (when Key is "*")
+				if envVar.ConfigRef.Key == "*" {
+					// Extract all key-value pairs from the configmap
+					for key, value := range configMap.Data {
+						envName := key
+						if envVar.Prefix != "" {
+							envName = envVar.Prefix + key
+						}
+						newEnvVar := extractor.EnvVar{
+							Name:   envName,
+							Value:  value,
+							Source: extractor.SourceConfigMap,
+							ConfigRef: &extractor.ConfigMapKeyRef{
+								Name: envVar.ConfigRef.Name,
+								Key:  key,
+							},
+						}
+						resolved = append(resolved, newEnvVar)
+					}
 				} else {
-					fmt.Fprintf(os.Stderr, "Warning: key %s not found in configmap %s\n", envVar.ConfigRef.Key, envVar.ConfigRef.Name)
+					// Handle specific key reference
+					if value, ok := configMap.Data[envVar.ConfigRef.Key]; ok {
+						envVar.Value = value
+					} else {
+						fmt.Fprintf(os.Stderr, "Warning: key %s not found in configmap %s\n", envVar.ConfigRef.Key, envVar.ConfigRef.Name)
+					}
+					resolved = append(resolved, envVar)
 				}
+			} else {
+				resolved = append(resolved, envVar)
 			}
-			resolved = append(resolved, envVar)
 
 		default:
 			resolved = append(resolved, envVar)

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -e
+
+echo "=== Integration Test for kubectl-eex ==="
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Function to check if value matches expected
+check_value() {
+    local env_name=$1
+    local expected=$2
+    local actual=$3
+    
+    if [ "$actual" = "$expected" ]; then
+        echo -e "${GREEN}✓ $env_name: $actual${NC}"
+        return 0
+    else
+        echo -e "${RED}✗ $env_name: expected '$expected', got '$actual'${NC}"
+        return 1
+    fi
+}
+
+# Test 1: Extract environment variables from deployment
+echo ""
+echo "Test 1: Extracting environment variables from deployment..."
+OUTPUT=$(./kubectl-eex deployment test-app -n test-keex)
+
+# Create a temporary file to source the environment variables
+TMPFILE=$(mktemp)
+echo "$OUTPUT" > "$TMPFILE"
+
+# Source the file to get all environment variables
+set -a
+source "$TMPFILE"
+set +a
+
+# Clean up
+rm -f "$TMPFILE"
+
+# Test direct environment variable
+echo ""
+echo "Testing direct environment variables:"
+check_value "DIRECT_ENV" "direct-value" "$DIRECT_ENV"
+
+# Test individual secret references
+echo ""
+echo "Testing individual secret references:"
+check_value "DB_HOST" "localhost" "$DB_HOST"
+check_value "DB_PORT" "5432" "$DB_PORT"
+
+# Test individual configmap references
+echo ""
+echo "Testing individual configmap references:"
+check_value "APPLICATION_ENV" "production" "$APPLICATION_ENV"
+check_value "APPLICATION_PORT" "8080" "$APPLICATION_PORT"
+
+# Test envFrom secret (recursive functionality)
+echo ""
+echo "Testing envFrom secret (entire secret imported):"
+check_value "DATABASE_HOST" "localhost" "$DATABASE_HOST"
+check_value "DATABASE_PORT" "5432" "$DATABASE_PORT"
+check_value "DATABASE_USER" "admin" "$DATABASE_USER"
+check_value "DATABASE_PASS" "secret123" "$DATABASE_PASS"
+check_value "API_KEY" "abcdefghijk" "$API_KEY"
+
+# Test envFrom configmap (recursive functionality)
+echo ""
+echo "Testing envFrom configmap (entire configmap imported):"
+check_value "APP_ENV" "production" "$APP_ENV"
+check_value "APP_DEBUG" "false" "$APP_DEBUG"
+check_value "APP_LOG_LEVEL" "info" "$APP_LOG_LEVEL"
+check_value "APP_PORT" "8080" "$APP_PORT"
+check_value "APP_NAME" "test-application" "$APP_NAME"
+
+# Test envFrom with prefix
+echo ""
+echo "Testing envFrom with prefix (secret):"
+check_value "PARTIAL_PARTIAL_KEY_1" "value1" "$PARTIAL_PARTIAL_KEY_1"
+check_value "PARTIAL_PARTIAL_KEY_2" "value2" "$PARTIAL_PARTIAL_KEY_2"
+check_value "PARTIAL_PARTIAL_KEY_3" "value3" "$PARTIAL_PARTIAL_KEY_3"
+
+echo ""
+echo "Testing envFrom with prefix (configmap):"
+check_value "CONFIG_PREFIX_CONFIG_A" "value-a" "$CONFIG_PREFIX_CONFIG_A"
+check_value "CONFIG_PREFIX_CONFIG_B" "value-b" "$CONFIG_PREFIX_CONFIG_B"
+check_value "CONFIG_PREFIX_CONFIG_C" "value-c" "$CONFIG_PREFIX_CONFIG_C"
+
+# Test 2: Test with different output formats
+echo ""
+echo "Test 2: Testing different output formats..."
+
+echo "Testing docker format:"
+./kubectl-eex deployment test-app -n test-keex -o docker | grep -q "ENV DATABASE_HOST=\"localhost\"" || (echo "Docker format test failed" && exit 1)
+echo -e "${GREEN}✓ Docker format test passed${NC}"
+
+echo "Testing dotenv format:"
+./kubectl-eex deployment test-app -n test-keex -o dotenv | grep -q "DATABASE_HOST=localhost" || (echo "Dotenv format test failed" && exit 1)
+echo -e "${GREEN}✓ Dotenv format test passed${NC}"
+
+echo ""
+echo -e "${GREEN}=== All integration tests passed! ===${NC}"

--- a/test/k8s/configmap.yaml
+++ b/test/k8s/configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+data:
+  APP_ENV: production
+  APP_DEBUG: "false"
+  APP_LOG_LEVEL: info
+  APP_PORT: "8080"
+  APP_NAME: test-application
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-partial
+data:
+  CONFIG_A: value-a
+  CONFIG_B: value-b
+  CONFIG_C: value-c

--- a/test/k8s/deployment.yaml
+++ b/test/k8s/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: test-container
+        image: busybox:latest
+        command: ["sleep", "3600"]
+        env:
+        # Direct environment variables
+        - name: DIRECT_ENV
+          value: "direct-value"
+        # Individual secret references
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: test-secret
+              key: DATABASE_HOST
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: test-secret
+              key: DATABASE_PORT
+        # Individual configmap references
+        - name: APPLICATION_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: test-configmap
+              key: APP_ENV
+        - name: APPLICATION_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: test-configmap
+              key: APP_PORT
+        # envFrom for entire secret (testing recursive functionality)
+        envFrom:
+        - secretRef:
+            name: test-secret
+        - configMapRef:
+            name: test-configmap
+        - secretRef:
+            name: test-secret-partial
+          prefix: PARTIAL_
+        - configMapRef:
+            name: test-configmap-partial
+          prefix: CONFIG_PREFIX_

--- a/test/k8s/secret.yaml
+++ b/test/k8s/secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque
+data:
+  DATABASE_HOST: bG9jYWxob3N0  # localhost
+  DATABASE_PORT: NTQzMg==       # 5432
+  DATABASE_USER: YWRtaW4=       # admin
+  DATABASE_PASS: c2VjcmV0MTIz   # secret123
+  API_KEY: YWJjZGVmZ2hpams=     # abcdefghijk
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret-partial
+type: Opaque
+data:
+  PARTIAL_KEY_1: dmFsdWUx       # value1
+  PARTIAL_KEY_2: dmFsdWUy       # value2
+  PARTIAL_KEY_3: dmFsdWUz       # value3


### PR DESCRIPTION
This pull request introduces significant updates to the `kubectl-eex` plugin, focusing on recursive environment variable extraction, integration testing, and Kubernetes resource definitions. The most important changes include adding support for `envFrom` with prefixes, implementing integration tests, and defining test Kubernetes resources.

### Feature Enhancements:
* **Support for `envFrom` with prefixes**:
  - Updated `extractFromPodSpec` in `cmd/kubectl-eex/main.go` to handle prefixes for `envFrom` secrets and configmaps.
  - Added a `Prefix` field to the `EnvVar` struct in `pkg/extractor/types.go` to support prefix functionality.
  - Enhanced `Resolver.ResolveAll` in `pkg/resolver/resolver.go` to process recursive key-value pairs with prefixes for secrets and configmaps. [[1]](diffhunk://#diff-fba8389f4ee475809564a9fccacf13e34f1e33d4ccb8a7189f75b462740d0f50R103-R133) [[2]](diffhunk://#diff-fba8389f4ee475809564a9fccacf13e34f1e33d4ccb8a7189f75b462740d0f50R149-R179)

### Integration Testing:
* **Integration test workflow**:
  - Added a GitHub Actions workflow (`integration-test.yml`) to automate integration tests for `kubectl-eex`.
* **Integration test script**:
  - Created `test/integration/test.sh` to validate recursive environment variable extraction, prefix handling, and output formats.

### Kubernetes Resource Definitions:
* **Test resources for integration tests**:
  - Added `test/k8s/deployment.yaml` to define a deployment with various environment variable configurations.
  - Added `test/k8s/secret.yaml` and `test/k8s/configmap.yaml` to define secrets and configmaps for testing recursive and prefixed environment variable extraction. [[1]](diffhunk://#diff-f34532701fafd5cdb2f4f60b846703f58a7a2821d800715cd53963f6edbe74b3R1-R21) [[2]](diffhunk://#diff-c7a6370a0e61267d2a6859c4bc916dae0418bf164c4936209064e9b061639a46R1-R19)