### PR TITLE
feat: add dotenv and compose output formats to keex CLI

### DIFF
--- a/cmd/keex/extract.go
+++ b/cmd/keex/extract.go
@@ -34,7 +34,7 @@ for use with docker run or shell commands.`,
 	}
 
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "Manifest file path (\"-\" for stdin)")
-	cmd.Flags().StringVar(&opts.mode, "mode", "env", "Output mode: docker|env")
+	cmd.Flags().StringVar(&opts.mode, "mode", "env", "Output mode: docker|env|dotenv|compose")
 	cmd.Flags().StringVar(&opts.container, "container", "", "Target container name")
 	cmd.Flags().StringVar(&opts.context, "context", "", "kubeconfig context (default: current)")
 	cmd.Flags().StringVar(&opts.namespace, "namespace", "", "Kubernetes namespace (default: manifest/ns)")
@@ -45,8 +45,9 @@ for use with docker run or shell commands.`,
 
 func runExtract(opts *extractOptions) error {
 	// Validate mode
-	if opts.mode != "docker" && opts.mode != "env" {
-		return fmt.Errorf("invalid mode: %s (must be docker or env)", opts.mode)
+	validModes := map[string]bool{"docker": true, "env": true, "dotenv": true, "compose": true}
+	if !validModes[opts.mode] {
+		return fmt.Errorf("invalid mode: %s (must be docker, env, dotenv, or compose)", opts.mode)
 	}
 
 	// Read manifest
@@ -99,6 +100,10 @@ func runExtract(opts *extractOptions) error {
 		output = formatter.FormatDocker(envVars, opts.redact)
 	case "env":
 		output = formatter.FormatShell(envVars, false, opts.redact)
+	case "dotenv":
+		output = formatter.FormatDotenv(envVars)
+	case "compose":
+		output = formatter.FormatCompose(envVars)
 	}
 
 	fmt.Println(output)


### PR DESCRIPTION
## Summary
- Added support for `--mode dotenv` and `--mode compose` output formats to the keex CLI
- Updated mode validation logic to accept the new formats
- Utilized existing `FormatDotenv` and `FormatCompose` functions from the formatter package

## Test plan
- [x] Built the keex binary successfully
- [x] Tested `keex extract -f examples/deployment.yaml --mode dotenv` - outputs .env format
- [x] Tested `keex extract -f examples/deployment.yaml --mode compose` - outputs docker-compose format
- [x] Ran all tests with `go test ./...` - all passing
- [x] Formatted code with `go fmt ./...`

Fixes #24

🤖 Generated with [Claude Code](https://claude.ai/code)