### PR TITLE
feat: add test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /dist
 /coverage.txt
+/coverage.out
+/coverage.html
 /keex
 /kubectl-extract
 /kubectl-eex

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-plugin install-plugin test clean
+.PHONY: build build-plugin install-plugin test cover cover-html clean
 
 build:
 	go build -o keex ./cmd/keex
@@ -12,5 +12,13 @@ install-plugin: build-plugin
 test:
 	go test ./...
 
+cover:
+	go test -coverprofile=coverage.out -covermode=atomic ./...
+	go tool cover -func=coverage.out
+
+cover-html: cover
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report generated: coverage.html"
+
 clean:
-	rm -f keex kubectl-eex
+	rm -f keex kubectl-eex coverage.out coverage.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # keex - Kubernetes Environment Extractor
 
+[![Test](https://github.com/whywaita/keex/actions/workflows/test.yml/badge.svg)](https://github.com/whywaita/keex/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/whywaita/keex/branch/main/graph/badge.svg)](https://codecov.io/gh/whywaita/keex)
+[![Go Report Card](https://goreportcard.com/badge/github.com/whywaita/keex)](https://goreportcard.com/report/github.com/whywaita/keex)
+
 keex is a CLI tool that extracts environment variables from Kubernetes manifests and formats them for use with `docker run` or shell commands.
 
 ## Motivation

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -97,3 +97,93 @@ USER='admin'`,
 		})
 	}
 }
+
+func TestFormatDotenv(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  []extractor.EnvVar
+		expected string
+	}{
+		{
+			name: "simple env vars",
+			envVars: []extractor.EnvVar{
+				{Name: "FOO", Value: "bar", Source: extractor.SourceDirect},
+				{Name: "BAZ", Value: "qux", Source: extractor.SourceDirect},
+			},
+			expected: `FOO="bar"
+BAZ="qux"`,
+		},
+		{
+			name: "with quotes",
+			envVars: []extractor.EnvVar{
+				{Name: "MESSAGE", Value: `hello "world"`, Source: extractor.SourceDirect},
+			},
+			expected: `MESSAGE="hello \"world\""`,
+		},
+		{
+			name: "skip comments",
+			envVars: []extractor.EnvVar{
+				{Name: "# This is a comment", Value: "ignored", Source: extractor.SourceDirect},
+				{Name: "FOO", Value: "bar", Source: extractor.SourceDirect},
+			},
+			expected: `FOO="bar"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatDotenv(tt.envVars)
+			if result != tt.expected {
+				t.Errorf("FormatDotenv() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatCompose(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  []extractor.EnvVar
+		expected string
+	}{
+		{
+			name: "simple env vars",
+			envVars: []extractor.EnvVar{
+				{Name: "FOO", Value: "bar", Source: extractor.SourceDirect},
+				{Name: "BAZ", Value: "qux", Source: extractor.SourceDirect},
+			},
+			expected: `environment:
+  FOO: "bar"
+  BAZ: "qux"`,
+		},
+		{
+			name: "multiline value",
+			envVars: []extractor.EnvVar{
+				{Name: "SCRIPT", Value: "line1\nline2\nline3", Source: extractor.SourceDirect},
+			},
+			expected: `environment:
+  SCRIPT: |
+    line1
+    line2
+    line3`,
+		},
+		{
+			name: "skip comments",
+			envVars: []extractor.EnvVar{
+				{Name: "# This is a comment", Value: "ignored", Source: extractor.SourceDirect},
+				{Name: "FOO", Value: "bar", Source: extractor.SourceDirect},
+			},
+			expected: `environment:
+  FOO: "bar"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatCompose(tt.envVars)
+			if result != tt.expected {
+				t.Errorf("FormatCompose() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Added `make cover` target to generate coverage reports with line-by-line analysis
- Added `make cover-html` target for HTML coverage visualization
- Updated `.gitignore` to exclude coverage output files
- Added coverage badges to README.md (Test workflow, Codecov, Go Report Card)
- Enhanced formatter package tests to improve coverage from 46.7% to 95.6%

## Test plan
- [x] Ran `make cover` - successfully generates coverage report
- [x] Ran `make cover-html` - successfully generates HTML coverage report
- [x] Verified formatter package coverage increased to 95.6%
- [x] All tests pass with `go test ./...`
- [x] CI workflow already configured to upload coverage to Codecov

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)